### PR TITLE
Added CocoaConf dates & cities for 2014

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ All-English conferences for **cocoa** developers.
 * [mdevcon](http://mdevcon.com/) | **March 7-8** | Amsterdam, Netherland
 * [CocoaConf Chicago](http://cocoaconf.com/chicago-2014/home) | **March 7-8** | Chicago, Illinois
 * [NSConference](http://nsconference.com/) | **March 17-19** | Leicester, England
-* [CocoaConf DC](http://cocoaconf.com/dc-2014/home) | **March 28-29** | Washington, D.C.
+* [CocoaConf DC](http://cocoaconf.com/dc-2014/home) | **March 28-29** | Herndon, Virginia
 * [CocoaConf Austin](http://cocoaconf.com/austin-2014/home) | **April 4-5** | Austin, Texas
 * [CocoaConf San Jose](http://cocoaconf.com/sanjose-2014/home) | **April 25-26** | San Jose, California
 * [úll](http://2014.ull.ie/) | **April 28-30** | Dublin, Ireland


### PR DESCRIPTION
CocoaConf will be in Chicago, DC, Austin, San Jose, and Raleigh in 2014
