### PR TITLE
Correct Relative links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #iOS & macOS Developers Conferences
 All-English conferences for **Cocoa** developers. Index:
-- [Cocoa-only](https://github.com/Lascorbe/CocoaConferences/blob/master/README.md#cocoa-only)
-- [Related to Cocoa or Mobile in general](https://github.com/Lascorbe/CocoaConferences/blob/master/README.md#related-to-cocoa-or-mobile-in-general)
+- [Cocoa-only](#cocoa-only)
+- [Related to Cocoa or Mobile in general](#related-to-cocoa-or-mobile-in-general)
 
 ## Cocoa-only
 

--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
 <p>All-English conferences for <strong>Cocoa</strong> developers. Index:</p>
 
 <ul>
-<li><a href="https://github.com/Lascorbe/CocoaConferences/blob/master/README.md#cocoa-only">Cocoa-only</a></li>
-<li><a href="https://github.com/Lascorbe/CocoaConferences/blob/master/README.md#related-to-cocoa-or-mobile-in-general">Related to Cocoa or Mobile in general</a></li>
+<li><a href="http://Lascorbe.github.io/CocoaConferences/#cocoa-only">Cocoa-only</a></li>
+<li><a href="http://Lascorbe.github.io/CocoaConferences/#related-to-cocoa-or-mobile-in-general">Related to Cocoa or Mobile in general</a></li>
 </ul>
 
 <h2>


### PR DESCRIPTION
They were pointing to the readme.md, now they are proper relative links.

You may have to regenerate the project page, I'm not sure.