### PR TITLE
Change ADDC abbreviation to the full name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All-English conferences for **Cocoa** developers.
 | [Craft Conference](http://craft-conf.com) | **April 22-24** | Budapest, Hungary | - |
 | [App Builders](http://www.appbuilders.ch) | **April 24-25** | Lausanne, Switzerland | [~~January 18~~](https://docs.google.com/forms/d/e/1FAIpQLSfvL9muXHeVUe9cujgwmLbXieCe_VC7s5fhWcXW_8KPa6KTVA/viewform) |
 | [DEVit Web Conference](http://devitconf.org/) | **May 20-21** | Thessaloniki, Greece | [February 5](https://goo.gl/forms/GssucZClBUGvnXr62) |
-| [ADDC](http://addconf.com/) | **June 22-23** | Barcelona, Spain | - |
+| [App Design & Development Conference](http://addconf.com/) | **June 22-23** | Barcelona, Spain | - |
 | [Release Notes](https://2017.releasenotes.tv/) | **October 16-18** | Chicago, IL, USA | - |
 
 # Has already happened... 


### PR DESCRIPTION
Hey there,

first of all, thanks for hosting us on this list. This is a small change proposed to more clearly display the name of the conference. I'll be following up with another PR in the next days once we announce CFP

Thanks for support & help