### PR TITLE
Updating ADDC name & URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All-English conferences for **Cocoa** developers.
 | [MobOS](http://romobos.com/) | **February 15-16, 2018** | 🇷🇴 Cluj-Napoca, Romania | n/a |
 | [Code Mobile](http://www.codemobile.co.uk) | **April 2-5, 2018** | 🇬🇧 Chester, UK | [~~August 31, 2017~~](http://www.codemobile.co.uk/call-for-speakers/)
 | [App Builders](https://www.appbuilders.ch/) | **April 16-17, 2018** | 🇨🇭 Lugano, Switzerland | n/a |
-| [ADDC](https://www.appbuilders.ch/) | **July 4-6, 2018** | 🇪🇸 Barcelona, Spain | n/a |
+| [ADDC - App Design & Development Conference](https://addconf.com/) | **July 4-6, 2018** | 🇪🇸 Barcelona, Spain | n/a |
 
 
 # Has already happened...


### PR DESCRIPTION
Hey there,

@mariusc already added newly announced ADDC 2018, however I'd like to propose two changes
- fully expanded name, as we would prefer to promote it,
- the correct URL

Thanks for keeping up this great list!