### PR TITLE
Fixes to Swift TO (date and switched to main website)

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1349,5 +1349,5 @@
   location: 🇨🇦 Toronto, Canada
   cocoa-only: true
   cfp:
-    link: https://www.swiftconf.to/
+    link: https://www.papercall.io/swift-to
     deadline: 2019-06-30

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1344,10 +1344,10 @@
 
 - name: Swift TO
   link: https://www.swiftconf.to/
-  start: 2019-09-13
-  end: 2019-09-13
+  start: 2019-08-13
+  end: 2019-08-13
   location: 🇨🇦 Toronto, Canada
   cocoa-only: true
   cfp:
-    link: https://www.papercall.io/swift-to
+    link: https://www.swiftconf.to/
     deadline: 2019-06-30


### PR DESCRIPTION
Date on cocoaconferences.com was September 13, actual date is August 13. Presumably typo.

(Note I am not directly affiliated with the conference)