### PR TITLE
Added AppDevcon

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -23,6 +23,12 @@
 #
 ##########################
 
+- name: Appdevcon
+  link: https://appdevcon.nl
+  start: 2020-03-10
+  end: 2020-03-13
+  location: 🇳🇱 Amsterdam, The Netherlands
+  cocoa-only: false
 - name: iOSCon 2020
   link: https://skillsmatter.com/conferences/12283-ioscon-2020-the-conference-for-ios-and-swift-developers
   start: 2020-03-19


### PR DESCRIPTION
CFP can be found on http://appdevcon.nl from September 1st..

I will add it then.