### PR TITLE
Add UIKonf 2020

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -23,6 +23,13 @@
 #
 ##########################
 
+- name: UIKonf
+  link: https://uikonf.com
+  start: 2020-05-17
+  end: 2020-05-20
+  location: 🇩🇪 Berlin, Germany
+  cocoa-only: true
+
 - name: ADDC - App Design & Development Conference
   link: https://addconf.com/
   start: 2020-06-24


### PR DESCRIPTION
Adds [UIKonf 2020][uikonf] details.

The CfP link isn't available (as detailed [here][cfp]), I'll make a new PR with an update once the link is available.

[uikonf]: https://uikonf.com
[cfp]: https://us9.campaign-archive.com/?u=08d7d9a7a55f501920eb76453&id=434ab474d7