### PR TITLE
Bye Bye iOS Con

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -143,16 +143,6 @@
     link: https://docs.google.com/forms/d/e/1FAIpQLSfDVG0D_F71flB4MnfZwnnJOxoBvHzMyOjynEgd3JnG31dgow/viewform
     deadline: 2019-12-01
 
-- name: iOSCon 2020
-  link: https://skillsmatter.com/conferences/12283-ioscon-2020-the-conference-for-ios-and-swift-developers
-  start: 2020-03-19
-  end: 2020-03-20
-  location: 🇬🇧 London, UK
-  cocoa-only: true
-  cfp:
-    link: https://docs.google.com/forms/d/e/1FAIpQLSdWK2Ob5WcLvu_8ghVT5thYYh7x61KjT_vHi51t7PDvjwk82Q/viewform
-    deadline: 2019-11-06
-
 - name: CodeMobile
   link: https://www.codemobile.co.uk/
   start: 2020-04-28


### PR DESCRIPTION
Skills Matter, the organizer of iOSCon was placed into administration, so it looks like iOSCon 2019 was the last edition of this wonderful conference.