### PR TITLE
ICS files for subscribing in Calendar

### DIFF
--- a/_includes/event.ics
+++ b/_includes/event.ics
@@ -6,13 +6,13 @@ SUMMARY:{{ conference.name }}
 LOCATION:{% if conference.location %}{{ conference.location }}{% else %}TBA{% endif %}
 {% if conference.start %}
 {%- assign start = conference.start | split: "-" -%}
-DTSTART:{{ start[0] }}{{ start[1] }}{{ start[2] }}
+DTSTART;VALUE=DATE:{{ start[0] }}{{ start[1] }}{{ start[2] }}
 {% if conference.end %}
-{%- assign end = conference.end | split: "-" -%}
-DTEND:{{ end[0] }}{{ end[1] }}{{ end[2] }}
+	{%- assign end = conference.end -%}
 {%- else -%}
-DTEND:{{ start[0] }}{{ start[1] }}{{ start[2] }}
+	{%- assign end = conference.start -%}
 {%- endif -%}
-{% endif %}
+DTEND;VALUE=DATE:{{ end | date: "%s" | plus: 129600 | date: "%Y%m%d" }}
+{% endif -%}
 DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%S"}}
 END:VEVENT

--- a/_includes/event.ics
+++ b/_includes/event.ics
@@ -1,0 +1,18 @@
+{%- assign conference = include.conference -%}
+BEGIN:VEVENT
+UID:{{ conference.name | url_encode }}{% if conference.start %}-{{ conference.start }}{% endif %}
+SUMMARY:{{ conference.name }}
+{% if conference.link %}URL:{{ conference.link }}{% endif %}
+LOCATION:{% if conference.location %}{{ conference.location }}{% else %}TBA{% endif %}
+{% if conference.start %}
+{%- assign start = conference.start | split: "-" -%}
+DTSTART:{{ start[0] }}{{ start[1] }}{{ start[2] }}
+{% if conference.end %}
+{%- assign end = conference.end | split: "-" -%}
+DTEND:{{ end[0] }}{{ end[1] }}{{ end[2] }}
+{%- else -%}
+DTEND:{{ start[0] }}{{ start[1] }}{{ start[2] }}
+{%- endif -%}
+{% endif %}
+DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%S"}}
+END:VEVENT

--- a/api/all.ics
+++ b/api/all.ics
@@ -1,0 +1,11 @@
+---
+---
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//lascorbe/CocoaConferences/all v1.0//EN
+CALSCALE:GREGORIAN
+NAME:All Conferences
+{% for conference in site.data.conferences %}
+{%- include event.ics conference=conference -%}
+{% endfor %}
+END:VCALENDAR

--- a/api/cocoa.ics
+++ b/api/cocoa.ics
@@ -4,7 +4,7 @@ BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//lascorbe/CocoaConferences/cocoa v1.0//EN
 CALSCALE:GREGORIAN
-NAME:All Conferences
+NAME:Cocoa Conferences
 {% for conference in site.data.conferences %}
 {%- if conference.cocoa-only == true -%}
 {%- include event.ics conference=conference -%}

--- a/api/cocoa.ics
+++ b/api/cocoa.ics
@@ -1,0 +1,13 @@
+---
+---
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//lascorbe/CocoaConferences/cocoa v1.0//EN
+CALSCALE:GREGORIAN
+NAME:All Conferences
+{% for conference in site.data.conferences %}
+{%- if conference.cocoa-only == true -%}
+{%- include event.ics conference=conference -%}
+{%- endif -%}
+{% endfor %}
+END:VCALENDAR

--- a/api/mobile.ics
+++ b/api/mobile.ics
@@ -4,7 +4,7 @@ BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//lascorbe/CocoaConferences/mobile v1.0//EN
 CALSCALE:GREGORIAN
-NAME:All Conferences
+NAME:Mobile Conferences
 {% for conference in site.data.conferences %}
 {%- if conference.cocoa-only == false -%}
 {%- include event.ics conference=conference -%}

--- a/api/mobile.ics
+++ b/api/mobile.ics
@@ -1,0 +1,13 @@
+---
+---
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//lascorbe/CocoaConferences/mobile v1.0//EN
+CALSCALE:GREGORIAN
+NAME:All Conferences
+{% for conference in site.data.conferences %}
+{%- if conference.cocoa-only == false -%}
+{%- include event.ics conference=conference -%}
+{%- endif -%}
+{% endfor %}
+END:VCALENDAR

--- a/index.md
+++ b/index.md
@@ -6,6 +6,8 @@ description: List of cocoa conferences for iOS & macOS developers
 
 ## All-English conferences for **Cocoa** developers.
 
+You can download a Calendar for all conferences [here](api/all.ics), one for Cocoa conferences [here](api/cocoa.ics), and one for mobile conferences [here](api/mobile.ics).
+
 <div id="upcoming"></div>
 
 ## Past Conferences


### PR DESCRIPTION
Implements #215

This adds three files to the generated site: `/api/all.ics`, `/api/cocoa.ics`, and `/api/mobile.ics`.

Every time the site is re-built, the three files are generated. They allow users to see all the conferences (or only cocoa conferences, or only mobile conferences) in their calendaring app of choice.

I've verified that the ICS files can be correctly read by Calendar.app.


<img width="828" alt="Screen Shot 2020-01-22 at 5 29 00 PM" src="https://user-images.githubusercontent.com/112699/72946623-aee81980-3d3c-11ea-9e16-5030be26d8ef.png">
