### PR TITLE
Remove Cancelled SwiftAveiro 2020 🦠

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -124,13 +124,6 @@
   cfp:
     link: https://t.dripemail2.com/c/eyJhY2NvdW50X2lkIjoiMTkzMzg1NCIsImRlbGl2ZXJ5X2lkIjoiZGFnenp6YnBhMTZnMWN3bDJ5aW8iLCJ1cmwiOiJodHRwczovL2RvY3MuZ29vZ2xlLmNvbS9mb3Jtcy9kL2UvMUZBSXBRTFNkWkdBS1FMbjhDbVN6MmRWa0R6VVVWVHAzZVYwSS03a3J4NVZVbkpRUnk5RmxEVlEvdmlld2Zvcm0_Yz0wXHUwMDI2dz0xXHUwMDI2X19zPXh4eHh4eHhcdTAwMjZfX3M9bXFzemhub213YWgyeWF2dnR1a3EifQ
 
-- name: SwiftAveiro
-  link: https://www.swiftaveiro.xyz/
-  location: 🇵🇹 Aveiro, Portugal
-  start: 2020-06-25
-  end: 2020-06-27
-  cocoa-only: true
-
 - name: 360iDev
   link: https://360idev.com
   start: 2020-08-16


### PR DESCRIPTION
From the [conference blog](https://www.swiftaveiro.xyz/blog/swift-aveiro-2020-canceled):

> # SwiftAveiro 2020 canceled
> 
> 03 Apr 2020
We have unfortunately decided to cancel SwiftAveiro 2020. While we were all very much looking forward to meeting all of you, we don’t see an in-person event as a possibility this year.
> 
> We’ve further decided not to change the format to an online event.
> 
> We look forward to seeing you all in a next edition of SwiftAveiro.
> 
> Tickets will be refunded. Those who have bought tickets will be notified of the procedure via email in the following days.
> 
> Thank you for understanding.
> 
> The SwiftAveiro team