### PR TITLE
Add WWDC 2020

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -133,6 +133,13 @@
   cfp:
     link: https://360idev.com/call-for-papers/
     deadline: 2020-05-08
+    
+- name: WWDC
+  link: https://developer.apple.com/wwdc/
+  start: 2020-06-22
+  end: 2020-06-26
+  location: online
+  cocoa-only: true
 
 - name: App Builders
   link: https://appbuilders.ch


### PR DESCRIPTION
Not quite sure what to add under location, I could find any precedent for online events in a quick scan of the file and other online conferences like UIKonf 2020 also had their typical location set.