### PR TITLE
iOSDevCampDC - CfP deadline extended

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1612,5 +1612,5 @@
   cocoa-only: true
   cfp:
     link: https://forms.gle/gWpQGta1mpykU6sE8
-    deadline: 2020-09-20
+    deadline: 2020-09-28
     


### PR DESCRIPTION
We've extended the CfP deadline to September 28.