### PR TITLE
Adds `AppDevCon 2023` to list of conferences

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -23,6 +23,16 @@
 #
 ##########################
 
+- name: AppDevCon
+  link: https://appdevcon.nl/
+  location: 🇳🇱 Amsterdam, Netherlands
+  start: 2023-05-09
+  end: 2023-05-12
+  cocoa-only: false
+  cfp:
+      link: https://sessionize.com/appdevcon-endpointcon-2023/
+      deadline: 2023-02-01
+
 - name: adiOS
   start: 2022-12-18
   end: 2022-12-18


### PR DESCRIPTION
- Adding the [AppDevCon 2023](https://appdevcon.nl/) to the list of conferences.