### PR TITLE
Fixes url on Swiftable

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -24,13 +24,13 @@
 ##########################
 
 - name: Swiftable 2023
-  link: https://https://www.swiftable.co/
+  link: https://www.swiftable.co/
   location: 🇦🇷 Buenos Aires, Argentina
   start: 2023-11-29
   end: 2023-12-1
   cocoa-only: true
   cfp:
-    link: https://https://www.papercall.io/swiftable2023
+    link: https://www.papercall.io/swiftable2023
     deadline: 2023-09-16
 
 - name: DO iOS


### PR DESCRIPTION
Links for the conference and CfP had double "https://" parts in the path making them invalid