### PR TITLE
Update conferences.yml dates to always have a 2 digit day.

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -27,7 +27,7 @@
   link: https://www.swiftable.co/
   location: 🇦🇷 Buenos Aires, Argentina
   start: 2023-11-29
-  end: 2023-12-1
+  end: 2023-12-01
   cocoa-only: true
   cfp:
     link: https://www.papercall.io/swiftable2023
@@ -35,8 +35,8 @@
 
 - name: DO iOS
   link: https://do-ios.com/
-  start: 2023-11-8
-  end: 2023-11-9
+  start: 2023-11-08
+  end: 2023-11-09
   location: 🇳🇱 Amsterdam, The Netherlands
   cocoa-only: true
   cfp:
@@ -76,7 +76,7 @@
 - name: try! Swift NYC 2023
   link: https://www.tryswift.co/events/2023/nyc/
   start: 2023-09-05
-  end: 2023-09-7
+  end: 2023-09-07
   location: 🇺🇸 New York City, NY, USA
   cocoa-only: true
     
@@ -1942,8 +1942,8 @@
     
 - name: Swiftable
   link: https://www.swiftable.co
-  start: 2022-12-1
-  end: 2022-12-2
+  start: 2022-12-01
+  end: 2022-12-02
   location: Autonomous City of Buenos Aires, 🇦🇷 Argentina
   cocoa-only: true
   cfp:


### PR DESCRIPTION
This fixes the issue noted by @stuffmc on the Do iOS entry.

https://mastodon.social/@stuffmc/110983047549321438

Turns out it was a simple issue related to the day components having a single digit.

I checked all month values too, they are all 2 digits.

Format of start and end HAS to be YYYY-MM-DD