### PR TITLE
Update conferences.yml for Deep Dish Swift 2025

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -25,6 +25,13 @@
 #
 ##########################
 
+- name: Deep Dish Swift
+  link: https://deepdishswift.com
+  start: 2025-04-27
+  end: 2025-04-29
+  location: 🇺🇸 Chicago, USA
+  cocoa-only: true
+
 - name: Swift Island
   link: https://swiftisland.nl
   start: 2024-08-27


### PR DESCRIPTION
I think I did this right 😊 

[Deep Dish Swift 2025](https://deepdishswift.com) will be April 27th to April 29th