### PR TITLE
Add FOSDEM 2025

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -87,12 +87,12 @@
       deadline: 2024-09-25
 
 - name: Swift DevRoom at FOSDEM 2025
-link: https://swiftlang.github.io/event-fosdem/
-start: 2025-02-01
-end: 2025-02-02
-location: 🇧🇪 Brussels, Belgium
-cocoa-only: true
-cfp:
+  link: https://swiftlang.github.io/event-fosdem/
+  start: 2025-02-01
+  end: 2025-02-02
+  location: 🇧🇪 Brussels, Belgium
+  cocoa-only: false
+  cfp:
     link: https://swiftlang.github.io/event-fosdem/
     deadline: 2024-11-30
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -86,6 +86,16 @@
       link: https://www.papercall.io/iosconfsg2025
       deadline: 2024-09-25
 
+- name: Swift DevRoom at FOSDEM 2025
+link: https://swiftlang.github.io/event-fosdem/
+start: 2025-02-01
+end: 2025-02-02
+location: 🇧🇪 Brussels, Belgium
+cocoa-only: true
+cfp:
+    link: https://swiftlang.github.io/event-fosdem/
+    deadline: 2024-11-30
+
 - name: try! Swift x AI Singapore
   link: https://www.tryswift.co/ai
   start: 2025-01-18


### PR DESCRIPTION
I wasn't sure if this is one that should be added or not, because the top of the website says "macOS, iOS, watchOS, tvOS developers"

This is the FOSDEM conference happening in Belgium, centered around open source projects, and Swift as a language has been accepted

This is the main conference website https://fosdem.org/2025/